### PR TITLE
Add CI workflows for build, formatting, and publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-14
           - windows-latest
     env:
       DOTNET_NOLOGO: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,61 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-14
+          - windows-latest
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 10 RC2 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.100-rc.2.25502.107
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json', '**/*.csproj', '**/*.props', '**/*.targets', '**/*.sln') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Install MAUI workloads (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: dotnet workload install maui-android --skip-manifest-update --source https://api.nuget.org/v3/index.json
+
+      - name: Install MAUI workloads (Windows/macOS)
+        if: matrix.os != 'ubuntu-latest'
+        run: dotnet workload install maui maui-android --skip-manifest-update --source https://api.nuget.org/v3/index.json
+
+      - name: Restore dependencies
+        run: dotnet restore NobUS.sln
+
+      - name: Build solution
+        run: dotnet build NobUS.sln -c Release --no-restore
+
+      - name: Run tests (if present)
+        shell: bash
+        run: |
+          set -euo pipefail
+          if find . -name '*Test*.csproj' | grep -q .; then
+            dotnet test NobUS.sln -c Release --no-build
+          else
+            echo "No test projects found. Skipping dotnet test."
+          fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,24 +38,24 @@ jobs:
 
       - name: Install MAUI workloads (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: dotnet workload install maui-android --skip-manifest-update --source https://api.nuget.org/v3/index.json
+        run: dotnet workload install maui-android --skip-manifest-update
 
       - name: Install MAUI workloads (Windows/macOS)
         if: matrix.os != 'ubuntu-latest'
-        run: dotnet workload install maui maui-android --skip-manifest-update --source https://api.nuget.org/v3/index.json
+        run: dotnet workload install maui maui-android --skip-manifest-update
 
       - name: Restore dependencies
         run: dotnet restore NobUS.sln
 
       - name: Build solution
-        run: dotnet build NobUS.sln -c Release --no-restore
+        run: dotnet build NobUS.sln
 
       - name: Run tests (if present)
         shell: bash
         run: |
           set -euo pipefail
           if find . -name '*Test*.csproj' | grep -q .; then
-            dotnet test NobUS.sln -c Release --no-build
+            dotnet test NobUS.sln --no-build
           else
             echo "No test projects found. Skipping dotnet test."
           fi

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,4 +26,4 @@ jobs:
         run: echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
 
       - name: Check formatting
-        run: csharpier --check .
+        run: csharpier check .

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,29 @@
+name: Format
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  csharpier:
+    runs-on: ubuntu-latest
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 10 RC2 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.100-rc.2.25502.107
+
+      - name: Install CSharpier
+        run: dotnet tool install --global csharpier
+
+      - name: Add dotnet tools to PATH
+        run: echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
+
+      - name: Check formatting
+        run: csharpier --check .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
             ${{ runner.os }}-nuget-
 
       - name: Install MAUI workloads
-        run: dotnet workload install maui maui-android --skip-manifest-update --source https://api.nuget.org/v3/index.json
+        run: dotnet workload install maui maui-android --skip-manifest-update
 
       - name: Restore dependencies
         run: dotnet restore NobUS.sln
@@ -37,28 +37,15 @@ jobs:
       - name: Publish MAUI Android package
         run: >-
           dotnet publish src/NobUS.Frontend.MAUI/NobUS.Frontend.MAUI.csproj
-          -c Release
           -f net10.0-android
           -p:RuntimeIdentifier=android-arm64
-          -p:AndroidPackageFormat=apk
-          --no-restore
-
       - name: Publish SportsWatcher (framework-dependent)
-        run: >-
-          dotnet publish src/NobUS.Daemon.SportsWatcher/NobUS.Daemon.SportsWatcher.csproj
-          -c Release
-          -r linux-x64
-          --self-contained false
-          -p:PublishAot=false
-          --no-restore
+        run: dotnet publish src/NobUS.Daemon.SportsWatcher/NobUS.Daemon.SportsWatcher.csproj
 
       - name: Publish SportsWatcher (self-contained Windows)
         run: >-
           dotnet publish src/NobUS.Daemon.SportsWatcher/NobUS.Daemon.SportsWatcher.csproj
-          -c Release
           -r win-x64
-          --self-contained true
-          --no-restore
 
       - name: Upload MAUI APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,82 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-artifacts:
+    runs-on: windows-latest
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 10 RC2 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.100-rc.2.25502.107
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json', '**/*.csproj', '**/*.props', '**/*.targets', '**/*.sln') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Install MAUI workloads
+        run: dotnet workload install maui maui-android --skip-manifest-update --source https://api.nuget.org/v3/index.json
+
+      - name: Restore dependencies
+        run: dotnet restore NobUS.sln
+
+      - name: Publish MAUI Android package
+        run: >-
+          dotnet publish src/NobUS.Frontend.MAUI/NobUS.Frontend.MAUI.csproj
+          -c Release
+          -f net10.0-android
+          -p:RuntimeIdentifier=android-arm64
+          -p:AndroidPackageFormat=apk
+          --no-restore
+
+      - name: Publish SportsWatcher (framework-dependent)
+        run: >-
+          dotnet publish src/NobUS.Daemon.SportsWatcher/NobUS.Daemon.SportsWatcher.csproj
+          -c Release
+          -r linux-x64
+          --self-contained false
+          -p:PublishAot=false
+          --no-restore
+
+      - name: Publish SportsWatcher (self-contained Windows)
+        run: >-
+          dotnet publish src/NobUS.Daemon.SportsWatcher/NobUS.Daemon.SportsWatcher.csproj
+          -c Release
+          -r win-x64
+          --self-contained true
+          --no-restore
+
+      - name: Upload MAUI APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: NobUS-Frontend-apk
+          path: build/publish/NobUS.Frontend.MAUI/**/*.apk
+          if-no-files-found: error
+
+      - name: Upload SportsWatcher DLL
+        uses: actions/upload-artifact@v4
+        with:
+          name: NobUS-SportsWatcher-dll
+          path: build/publish/NobUS.Daemon.SportsWatcher/**/NobUS.Daemon.SportsWatcher.dll
+          if-no-files-found: error
+
+      - name: Upload SportsWatcher EXE
+        uses: actions/upload-artifact@v4
+        with:
+          name: NobUS-SportsWatcher-exe
+          path: build/publish/NobUS.Daemon.SportsWatcher/**/NobUS.Daemon.SportsWatcher.exe
+          if-no-files-found: error

--- a/src/NobUS.Frontend.MAUI/build-configs/TargetFramework.csproj
+++ b/src/NobUS.Frontend.MAUI/build-configs/TargetFramework.csproj
@@ -3,10 +3,15 @@
     <!--suppress MsbuildTargetFrameworkTagInspection -->
     <TargetFrameworks>$(DotNetMajorVersion)-android</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">
-      $(TargetFrameworks);$(DotNetMajorVersion)-windows10.0.19041.0
-    </TargetFrameworks>
+      $(TargetFrameworks);
+      $(DotNetMajorVersion)-windows10.0.19041.0
+    </TargetFrameworks
+    >
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-      $(TargetFrameworks);$(DotNetMajorVersion)-ios;$(DotNetMajorVersion)-maccatalyst
-    </TargetFrameworks>
+      $(TargetFrameworks);
+      $(DotNetMajorVersion)-ios;
+      $(DotNetMajorVersion)-maccatalyst
+    </TargetFrameworks
+    >
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add a cross-platform build pipeline that installs the .NET 10 RC2 SDK, MAUI workloads, restores, builds, and runs tests when present
- enforce repository formatting via a dedicated CSharpier workflow
- publish Android and SportsWatcher artifacts on main pushes for downstream consumption

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68fdb69eb8008324bedbbee2d456630d