### PR TITLE
Generate SchemaClient during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -402,6 +402,7 @@ FodyWeavers.xsd
 # Resx codegen
 *.Designer.cs
 !src/NobUS.Resources/Definitions/StationsNRoutes.Designer.cs
+src/NobUS.DataContract.Reader.OfficialAPI/Client/SchemaClient.g.cs
 
 # Fonts
 *.[to]tf

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,11 +20,6 @@
     <PackageVersion Include="Reactor.Maui.ScaffoldGenerator" Version="2.0.15-beta" />
     <PackageVersion Include="MaterialColorUtilities.Maui" Version="0.3.0" />
     <!-- IO -->
-    <PackageVersion
-      Include="Microsoft.Extensions.ApiDescription.Client"
-      Version="10.0.0-rc.2.25502.107"
-    />
-    <PackageVersion Include="NSwag.ApiDescription.Client" Version="14.6.1" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <!-- CLI -->

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "nswag.consolecore": {
+      "version": "14.6.1",
+      "commands": [
+        "nswag"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -8,6 +8,12 @@
         "nswag"
       ],
       "rollForward": false
+    },
+    "csharpier": {
+      "version": "1.1.2",
+      "commands": [
+        "csharpier"
+      ]
     }
   }
 }

--- a/src/NobUS.DataContract.Reader.OfficialAPI/Adapter.cs
+++ b/src/NobUS.DataContract.Reader.OfficialAPI/Adapter.cs
@@ -11,11 +11,17 @@ internal static class Adapter
         string routeName,
         _etas rawEta
     ) =>
-        new(stationCode, rawEta.Jobid, routeName, TimeSpan.FromSeconds(rawEta.Eta_s), DateTime.Now);
+        new(
+            stationCode,
+            rawEta.Jobid ?? 0,
+            routeName,
+            TimeSpan.FromSeconds(Convert.ToDouble(rawEta.Eta_s ?? rawEta.Eta ?? 0)),
+            DateTime.Now
+        );
 
     internal static MassPoint AdaptMassPoint(Activebus rawMassPoint) =>
         new(
-            new Coordinate(rawMassPoint.Lng, rawMassPoint.Lat),
-            new Velocity(rawMassPoint.Speed, rawMassPoint.Direction)
+            new Coordinate(rawMassPoint.Lng ?? 0, rawMassPoint.Lat ?? 0),
+            new Velocity(rawMassPoint.Speed ?? 0, rawMassPoint.Direction ?? 0)
         );
 }

--- a/src/NobUS.DataContract.Reader.OfficialAPI/CongestedClient.cs
+++ b/src/NobUS.DataContract.Reader.OfficialAPI/CongestedClient.cs
@@ -133,7 +133,7 @@ public record CongestedClient : IClient
                 .Select(x =>
                     x._etas.Select(e =>
                             _shuttleJobs.AddOrUpdate(
-                                e.Jobid,
+                                e.Jobid!.Value,
                                 k => new ShuttleJob(
                                     k,
                                     Routes[x.RouteName],

--- a/src/NobUS.DataContract.Reader.OfficialAPI/NobUS.DataContract.Reader.OfficialAPI.csproj
+++ b/src/NobUS.DataContract.Reader.OfficialAPI/NobUS.DataContract.Reader.OfficialAPI.csproj
@@ -3,32 +3,25 @@
     <TargetFramework>$(DotNetMajorVersion)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <OpenApiReference
-      ClassName="SchemaClient"
-      CodeGenerator="NSwagCSharp"
-      Include="Resource\Schema.yaml"
-      Namespace="NobUS.DataContract.Reader.OfficialAPI.Client"
-    />
-    <None Remove="Resource\Schema.yaml" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.ApiDescription.Client">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-                runtime; build; native; contentfiles; analyzers; buildtransitive
-            </IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="NSwag.ApiDescription.Client">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-                runtime; build; native; contentfiles; analyzers; buildtransitive
-            </IncludeAssets>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NobUS.DataContract.Model\NobUS.DataContract.Model.csproj" />
     <ProjectReference Include="..\NobUS.Infrastructure\NobUS.Infrastructure.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Remove="Client/SchemaClient.g.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Client/SchemaClient.g.cs" Condition="Exists('Client/SchemaClient.g.cs')" />
+  </ItemGroup>
+  <Target Name="GenerateSchemaClient"
+          Inputs="schema.nswag;Resource/Schema.yaml"
+          Outputs="Client/SchemaClient.g.cs"
+          BeforeTargets="CoreCompile">
+    <MakeDir Directories="Client" />
+    <Exec Command="dotnet tool restore" WorkingDirectory="$(MSBuildProjectDirectory)" />
+    <Exec Command="dotnet tool run nswag run &quot;$(MSBuildProjectDirectory)/schema.nswag&quot;" WorkingDirectory="$(MSBuildProjectDirectory)" />
+  </Target>
 </Project>

--- a/src/NobUS.DataContract.Reader.OfficialAPI/NobUS.DataContract.Reader.OfficialAPI.csproj
+++ b/src/NobUS.DataContract.Reader.OfficialAPI/NobUS.DataContract.Reader.OfficialAPI.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(DotNetMajorVersion)</TargetFramework>
+    <NswagToolManifest>$(MSBuildProjectDirectory)$(DirectorySeparatorChar)..$(DirectorySeparatorChar)..$(DirectorySeparatorChar)dotnet-tools.json</NswagToolManifest>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
@@ -13,15 +14,15 @@
   <ItemGroup>
     <None Remove="Client/SchemaClient.g.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Client/SchemaClient.g.cs" Condition="Exists('Client/SchemaClient.g.cs')" />
-  </ItemGroup>
   <Target Name="GenerateSchemaClient"
           Inputs="schema.nswag;Resource/Schema.yaml"
           Outputs="Client/SchemaClient.g.cs"
           BeforeTargets="CoreCompile">
     <MakeDir Directories="Client" />
-    <Exec Command="dotnet tool restore" WorkingDirectory="$(MSBuildProjectDirectory)" />
-    <Exec Command="dotnet tool run nswag run &quot;$(MSBuildProjectDirectory)/schema.nswag&quot;" WorkingDirectory="$(MSBuildProjectDirectory)" />
+    <Exec Command="dotnet tool restore --tool-manifest &quot;$(NswagToolManifest)&quot;" WorkingDirectory="$(MSBuildProjectDirectory)" />
+    <Exec Command="dotnet tool run --tool-manifest &quot;$(NswagToolManifest)&quot; nswag run &quot;$(MSBuildProjectDirectory)$(DirectorySeparatorChar)schema.nswag&quot;" WorkingDirectory="$(MSBuildProjectDirectory)" />
+    <ItemGroup Condition="Exists('Client/SchemaClient.g.cs')">
+      <Compile Include="Client/SchemaClient.g.cs" />
+    </ItemGroup>
   </Target>
 </Project>

--- a/src/NobUS.DataContract.Reader.OfficialAPI/NobUS.DataContract.Reader.OfficialAPI.csproj
+++ b/src/NobUS.DataContract.Reader.OfficialAPI/NobUS.DataContract.Reader.OfficialAPI.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(DotNetMajorVersion)</TargetFramework>
-    <NswagToolManifest>$(MSBuildProjectDirectory)$(DirectorySeparatorChar)..$(DirectorySeparatorChar)..$(DirectorySeparatorChar)dotnet-tools.json</NswagToolManifest>
+    <NswagToolManifestDirectory>$(MSBuildProjectDirectory)/../..</NswagToolManifestDirectory>
+    <NswagToolManifest>$(NswagToolManifestDirectory)/dotnet-tools.json</NswagToolManifest>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
@@ -14,13 +15,21 @@
   <ItemGroup>
     <None Remove="Client/SchemaClient.g.cs" />
   </ItemGroup>
-  <Target Name="GenerateSchemaClient"
-          Inputs="schema.nswag;Resource/Schema.yaml"
-          Outputs="Client/SchemaClient.g.cs"
-          BeforeTargets="CoreCompile">
+  <Target
+    Name="GenerateSchemaClient"
+    Inputs="schema.nswag;Resource/Schema.yaml"
+    Outputs="Client/SchemaClient.g.cs"
+    BeforeTargets="CoreCompile"
+  >
     <MakeDir Directories="Client" />
-    <Exec Command="dotnet tool restore --tool-manifest &quot;$(NswagToolManifest)&quot;" WorkingDirectory="$(MSBuildProjectDirectory)" />
-    <Exec Command="dotnet tool run --tool-manifest &quot;$(NswagToolManifest)&quot; nswag run &quot;$(MSBuildProjectDirectory)$(DirectorySeparatorChar)schema.nswag&quot;" WorkingDirectory="$(MSBuildProjectDirectory)" />
+    <Exec
+      Command="dotnet tool restore --tool-manifest &quot;$(NswagToolManifest)&quot;"
+      WorkingDirectory="$(NswagToolManifestDirectory)"
+    />
+    <Exec
+      Command="dotnet tool run nswag run &quot;$(MSBuildProjectDirectory)/schema.nswag&quot;"
+      WorkingDirectory="$(NswagToolManifestDirectory)"
+    />
     <ItemGroup Condition="Exists('Client/SchemaClient.g.cs')">
       <Compile Include="Client/SchemaClient.g.cs" />
     </ItemGroup>

--- a/src/NobUS.DataContract.Reader.OfficialAPI/Utility.cs
+++ b/src/NobUS.DataContract.Reader.OfficialAPI/Utility.cs
@@ -24,7 +24,9 @@ internal static class Utility
         shuttles
             .Where(ss => ss != null)
             .Where(ss => ss._etas != null)
-            .Where(ss => ss.Busstopcode != null && ss.Busstopcode.Length >= 2 && ss.Busstopcode[^2..] != "-E")
+            .Where(ss =>
+                ss.Busstopcode != null && ss.Busstopcode.Length >= 2 && ss.Busstopcode[^2..] != "-E"
+            )
             .Where(ss => ss._etas.Count != 0)
             .SelectMany(ss => ss._etas)
             .Where(x => x != null)
@@ -38,14 +40,15 @@ internal static class Utility
         shuttles
             .Where(ss => ss != null)
             .Where(ss => ss._etas != null)
-            .Where(ss => ss.Busstopcode != null && ss.Busstopcode.Length >= 2 && ss.Busstopcode[^2..] != "-E")
+            .Where(ss =>
+                ss.Busstopcode != null && ss.Busstopcode.Length >= 2 && ss.Busstopcode[^2..] != "-E"
+            )
             .Where(ss => ss._etas.Count != 0)
             .Select(ss =>
                 (
                     ss.Name,
-                    (ICollection<_etas>)ss._etas
-                        .Where(eta => eta != null && eta.Jobid.HasValue)
-                        .ToList()
+                    (ICollection<_etas>)
+                        ss._etas.Where(eta => eta != null && eta.Jobid.HasValue).ToList()
                 )
             );
 }

--- a/src/NobUS.DataContract.Reader.OfficialAPI/Utility.cs
+++ b/src/NobUS.DataContract.Reader.OfficialAPI/Utility.cs
@@ -24,10 +24,11 @@ internal static class Utility
         shuttles
             .Where(ss => ss != null)
             .Where(ss => ss._etas != null)
-            .Where(ss => ss.Busstopcode[^2..] != "-E")
+            .Where(ss => ss.Busstopcode != null && ss.Busstopcode.Length >= 2 && ss.Busstopcode[^2..] != "-E")
             .Where(ss => ss._etas.Count != 0)
             .SelectMany(ss => ss._etas)
             .Where(x => x != null)
+            .Where(x => x.Jobid.HasValue)
             .Distinct();
 
     public static IEnumerable<(
@@ -37,7 +38,14 @@ internal static class Utility
         shuttles
             .Where(ss => ss != null)
             .Where(ss => ss._etas != null)
-            .Where(ss => ss.Busstopcode[^2..] != "-E")
+            .Where(ss => ss.Busstopcode != null && ss.Busstopcode.Length >= 2 && ss.Busstopcode[^2..] != "-E")
             .Where(ss => ss._etas.Count != 0)
-            .Select(ss => (ss.Name, ss._etas));
+            .Select(ss =>
+                (
+                    ss.Name,
+                    (ICollection<_etas>)ss._etas
+                        .Where(eta => eta != null && eta.Jobid.HasValue)
+                        .ToList()
+                )
+            );
 }

--- a/src/NobUS.DataContract.Reader.OfficialAPI/schema.nswag
+++ b/src/NobUS.DataContract.Reader.OfficialAPI/schema.nswag
@@ -1,0 +1,44 @@
+{
+  "runtime": "Net100",
+  "documentGenerator": {
+    "fromDocument": {
+      "url": "Resource/Schema.yaml"
+    }
+  },
+  "codeGenerators": {
+    "openApiToCSharpClient": {
+      "className": "SchemaClient",
+      "namespace": "NobUS.DataContract.Reader.OfficialAPI.Client",
+      "clientBaseClass": null,
+      "configurationClass": null,
+      "generateClientInterfaces": false,
+      "injectHttpClient": true,
+      "disposeHttpClient": false,
+      "protectedMethods": [],
+      "generateOptionalParameters": true,
+      "generateJsonMethods": true,
+      "enforceFlagEnums": false,
+      "parameterDateTimeFormat": "o",
+      "generateUpdateJsonSerializerSettingsMethod": true,
+      "useBaseUrl": true,
+      "generateSyncMethods": false,
+      "clientClassAccessModifier": "public",
+      "typeAccessModifier": "public",
+      "generateContractsOutput": false,
+      "contractsNamespace": null,
+      "generateDtoTypes": true,
+      "generateOptionalPropertiesAsNullable": true,
+      "requiredPropertiesMustBeDefined": true,
+      "output": "Client/SchemaClient.g.cs",
+      "useNewtonsoftJson": true,
+      "jsonLibrary": "NewtonsoftJson",
+      "generateDefaultValues": true,
+      "inlineNamedDictionaries": false,
+      "inlineNamedAny": false,
+      "generateCustomHeaders": true,
+      "generateClientClasses": true,
+      "classStyle": "Poco",
+      "propertyNameGeneratorType": "Default"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- remove the checked-in SchemaClient NSwag output and ignore the generated file
- run the NSwag CLI from a new MSBuild target so the client regenerates before compilation

## Testing
- dotnet build NobUS.sln *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fdbce98ed08324bd3f5424d8e15256