### PR TITLE
Revamp MAUI navigation UI and improve activity refresh

### DIFF
--- a/src/NobUS.Frontend.MAUI/Presentation/Components/DisposableComponent.cs
+++ b/src/NobUS.Frontend.MAUI/Presentation/Components/DisposableComponent.cs
@@ -1,4 +1,9 @@
-﻿namespace NobUS.Frontend.MAUI.Presentation.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NobUS.Frontend.MAUI.Presentation.Components;
 
 internal abstract class DisposableComponent : Component, IDisposable
 {
@@ -6,15 +11,15 @@ internal abstract class DisposableComponent : Component, IDisposable
 
     public void Dispose() =>
         Task.Run(() =>
-            _disposables
-                .Select(cr =>
+        {
+            foreach (var disposable in _disposables.ToList())
+            {
+                if (disposable.TryGetTarget(out var target))
                 {
-                    cr.TryGetTarget(out var c);
-                    return c;
-                })
-                .ToList()
-                .ForEach(c => c.Dispose())
-        );
+                    target.Dispose();
+                }
+            }
+        });
 
     protected internal void RegisterResource(IDisposable resource) =>
         _disposables.Add(new(resource));
@@ -33,15 +38,15 @@ internal abstract class DisposableComponent<T> : Component<T>, IDisposable
 
     public void Dispose() =>
         Task.Run(() =>
-            _disposables
-                .Select(cr =>
+        {
+            foreach (var disposable in _disposables.ToList())
+            {
+                if (disposable.TryGetTarget(out var target))
                 {
-                    cr.TryGetTarget(out var c);
-                    return c;
-                })
-                .ToList()
-                .ForEach(c => c.Dispose())
-        );
+                    target.Dispose();
+                }
+            }
+        });
 
     protected internal void RegisterResource(IDisposable resource) =>
         _disposables.Add(new(resource));

--- a/src/NobUS.Frontend.MAUI/Presentation/Components/NavigationBar.cs
+++ b/src/NobUS.Frontend.MAUI/Presentation/Components/NavigationBar.cs
@@ -1,4 +1,10 @@
-﻿using static NobUS.Frontend.MAUI.Presentation.Styles;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Graphics;
+using static NobUS.Frontend.MAUI.Presentation.Styles;
 
 namespace NobUS.Frontend.MAUI.Presentation.Components;
 
@@ -7,32 +13,73 @@ internal class NavigationBarState
     public NavigationBarItem SelectedItem { get; set; }
 }
 
+internal interface INavigationAware
+{
+    void OnNavigatedTo();
+
+    void OnNavigatedFrom();
+}
+
 internal class NavigationBar : Component<NavigationBarState>
 {
     private readonly List<NavigationBarItem> _items = new();
 
     public void Add(NavigationBarItem item) => _items.Add(item);
 
-    public override VisualNode Render() =>
-        new Grid("*,auto", "*")
+    public override VisualNode Render()
+    {
+        NavigationBarItem selectedItem = State.SelectedItem ?? _items.FirstOrDefault();
+
+        return new Grid("*,auto", "*")
         {
-            new ContentView { State.SelectedItem?.Content() }
-                .GridRow(0)
-                .HCenter(),
+            new Grid
+            {
+                _items.Select(item =>
+                    new ContentView { item.GetContent() }
+                        .IsVisible(item == selectedItem)
+                        .Opacity(item == selectedItem ? 1 : 0)
+                        .InputTransparent(item != selectedItem)
+                        .Margin(0, 0, 0, 12)
+                )
+            }
+                .Padding(0, 0, 0, 12)
+                .GridRow(0),
             new Border
             {
                 new CollectionView()
-                    .ItemsLayout(new HorizontalLinearItemsLayout().ItemSpacing(8))
+                    .ItemsLayout(new HorizontalLinearItemsLayout().ItemSpacing(16))
                     .ItemsSource(_items, RenderItem)
                     .ItemSizingStrategy(ItemSizingStrategy.MeasureAllItems)
                     .VCenter()
                     .HCenter(),
             }
-                .ToCard(0)
-                .HeightRequest(80)
-                .Background(Styler.Scheme.SurfaceContainer)
-                .GridRow(1),
-        }.Background(Styler.Scheme.Surface);
+                .StrokeShape(new RoundRectangle().CornerRadius(28))
+                .StrokeThickness(0)
+                .Stroke(Colors.Transparent)
+                .Shadow(new Shadow { Brush = new SolidColorBrush(Color.FromArgb("#22000000")), Opacity = 0.4f, Radius = 12, Offset = new Point(0, 4) })
+                .HeightRequest(84)
+                .Background(new LinearGradientBrush
+                {
+                    GradientStops =
+                    {
+                        new GradientStop(Styler.Scheme.SurfaceContainerHigh, 0.0f),
+                        new GradientStop(Styler.Scheme.SurfaceContainer, 1.0f),
+                    },
+                    EndPoint = new Point(1, 1),
+                })
+                .GridRow(1)
+                .Margin(20, 0, 20, 24),
+        }
+            .Background(new LinearGradientBrush
+            {
+                GradientStops =
+                {
+                    new GradientStop(Styler.Scheme.Surface, 0f),
+                    new GradientStop(Styler.Scheme.SurfaceContainer, 1f),
+                },
+                EndPoint = new Point(0.5, 1),
+            });
+    }
 
     private VisualNode RenderItem(NavigationBarItem item)
     {
@@ -46,41 +93,112 @@ internal class NavigationBar : Component<NavigationBarState>
                     .Text(char.ConvertFromUtf32((int)item.Icon))
                     .FontFamily("MIcon-Regular")
                     .TextColor(
-                        selected ? Styler.Scheme.OnSecondaryContainer : Styler.Scheme.OnSurface
+                        selected ? Styler.Scheme.OnSecondaryContainer : Styler.Scheme.OnSurfaceVariant
                     )
                     .FontSize(Sizes.Large * 1.2)
                     .HCenter(),
             }
-                .HeightRequest(32)
-                .WidthRequest(64)
-                .BackgroundColor(selected ? Styler.Scheme.SecondaryContainer : Colors.Transparent)
-                .ToCard(32),
+                .HeightRequest(36)
+                .WidthRequest(68)
+                .Background(new LinearGradientBrush
+                {
+                    GradientStops =
+                    {
+                        new GradientStop(
+                            selected ? Styler.Scheme.SecondaryContainer : Colors.Transparent,
+                            0f
+                        ),
+                        new GradientStop(
+                            selected ? Styler.Scheme.Secondary : Colors.Transparent,
+                            1f
+                        ),
+                    },
+                    EndPoint = new Point(1, 1),
+                })
+                .ToCard(32)
+                .Padding(0, 4),
             new Label()
                 .Text(item.Title)
                 .FontSize(12)
                 .FontFamily(selected ? "SemiBold" : "Regular")
-                .TextColor(Styler.Scheme.OnSurface)
+                .TextColor(selected ? Styler.Scheme.OnSurface : Styler.Scheme.OnSurfaceVariant)
                 .HCenter(),
         }
             .OnTapped(() =>
             {
-                if (State.SelectedItem != item)
+                if (State.SelectedItem == item)
                 {
-                    SetState(s => s.SelectedItem = item);
+                    item.NotifyReactivated();
+                    return;
                 }
+
+                var previous = State.SelectedItem;
+                SetState(s => s.SelectedItem = item);
+                previous?.NotifyDeactivated();
+                item.NotifyActivated();
             })
-            .MinimumWidthRequest(48)
-            .Margin(0, 12, 0, 16)
-            .Spacing(4)
+            .MinimumWidthRequest(56)
+            .Margin(0, 16, 0, 20)
+            .Spacing(6)
             .HStart()
             .VCenter();
     }
 
     protected override void OnMounted()
     {
-        State.SelectedItem = _items.First();
+        if (_items.Any() && State.SelectedItem == null)
+        {
+            SetState(s => s.SelectedItem = _items.First());
+            _items.First().NotifyActivated();
+        }
+
         base.OnMounted();
     }
 }
 
-internal record NavigationBarItem(string Title, MaterialIcons Icon, Func<Component> Content);
+internal class NavigationBarItem
+{
+    private readonly Func<Component> _contentFactory;
+    private Component _content;
+
+    public NavigationBarItem(string title, MaterialIcons icon, Func<Component> contentFactory)
+    {
+        Title = title;
+        Icon = icon;
+        _contentFactory = contentFactory;
+    }
+
+    public string Title { get; }
+
+    public MaterialIcons Icon { get; }
+
+    public Component GetContent()
+    {
+        _content ??= _contentFactory();
+        return _content;
+    }
+
+    public void NotifyActivated()
+    {
+        if (GetContent() is INavigationAware aware)
+        {
+            aware.OnNavigatedTo();
+        }
+    }
+
+    public void NotifyReactivated()
+    {
+        if (_content is INavigationAware aware)
+        {
+            aware.OnNavigatedTo();
+        }
+    }
+
+    public void NotifyDeactivated()
+    {
+        if (_content is INavigationAware aware)
+        {
+            aware.OnNavigatedFrom();
+        }
+    }
+}

--- a/src/NobUS.Frontend.MAUI/Presentation/Components/NavigationBar.cs
+++ b/src/NobUS.Frontend.MAUI/Presentation/Components/NavigationBar.cs
@@ -1,7 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Maui.Controls;
+using Microsoft.Maui;
 using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Graphics;
 using static NobUS.Frontend.MAUI.Presentation.Styles;
@@ -10,7 +10,7 @@ namespace NobUS.Frontend.MAUI.Presentation.Components;
 
 internal class NavigationBarState
 {
-    public NavigationBarItem SelectedItem { get; set; }
+    public NavigationBarItem? SelectedItem { get; set; }
 }
 
 internal interface INavigationAware
@@ -28,7 +28,12 @@ internal class NavigationBar : Component<NavigationBarState>
 
     public override VisualNode Render()
     {
-        NavigationBarItem selectedItem = State.SelectedItem ?? _items.FirstOrDefault();
+        NavigationBarItem? selectedItem = State.SelectedItem ?? _items.FirstOrDefault();
+
+        if (selectedItem is null)
+        {
+            return new Grid();
+        }
 
         return new Grid("*,auto", "*")
         {
@@ -40,7 +45,7 @@ internal class NavigationBar : Component<NavigationBarState>
                         .Opacity(item == selectedItem ? 1 : 0)
                         .InputTransparent(item != selectedItem)
                         .Margin(0, 0, 0, 12)
-                )
+                ),
             }
                 .Padding(0, 0, 0, 12)
                 .GridRow(0),
@@ -53,32 +58,39 @@ internal class NavigationBar : Component<NavigationBarState>
                     .VCenter()
                     .HCenter(),
             }
-                .StrokeShape(new RoundRectangle().CornerRadius(28))
                 .StrokeThickness(0)
                 .Stroke(Colors.Transparent)
-                .Shadow(new Shadow { Brush = new SolidColorBrush(Color.FromArgb("#22000000")), Opacity = 0.4f, Radius = 12, Offset = new Point(0, 4) })
                 .HeightRequest(84)
-                .Background(new LinearGradientBrush
-                {
-                    GradientStops =
+                .Background(
+                    new Microsoft.Maui.Controls.LinearGradientBrush
                     {
-                        new GradientStop(Styler.Scheme.SurfaceContainerHigh, 0.0f),
-                        new GradientStop(Styler.Scheme.SurfaceContainer, 1.0f),
-                    },
-                    EndPoint = new Point(1, 1),
-                })
+                        GradientStops =
+                        {
+                            new Microsoft.Maui.Controls.GradientStop(
+                                Styler.Scheme.SurfaceContainerHigh,
+                                0.0f
+                            ),
+                            new Microsoft.Maui.Controls.GradientStop(
+                                Styler.Scheme.SurfaceContainer,
+                                1.0f
+                            ),
+                        },
+                        EndPoint = new Point(1, 1),
+                    }
+                )
                 .GridRow(1)
                 .Margin(20, 0, 20, 24),
-        }
-            .Background(new LinearGradientBrush
+        }.Background(
+            new Microsoft.Maui.Controls.LinearGradientBrush
             {
                 GradientStops =
                 {
-                    new GradientStop(Styler.Scheme.Surface, 0f),
-                    new GradientStop(Styler.Scheme.SurfaceContainer, 1f),
+                    new Microsoft.Maui.Controls.GradientStop(Styler.Scheme.Surface, 0f),
+                    new Microsoft.Maui.Controls.GradientStop(Styler.Scheme.SurfaceContainer, 1f),
                 },
                 EndPoint = new Point(0.5, 1),
-            });
+            }
+        );
     }
 
     private VisualNode RenderItem(NavigationBarItem item)
@@ -93,28 +105,32 @@ internal class NavigationBar : Component<NavigationBarState>
                     .Text(char.ConvertFromUtf32((int)item.Icon))
                     .FontFamily("MIcon-Regular")
                     .TextColor(
-                        selected ? Styler.Scheme.OnSecondaryContainer : Styler.Scheme.OnSurfaceVariant
+                        selected
+                            ? Styler.Scheme.OnSecondaryContainer
+                            : Styler.Scheme.OnSurfaceVariant
                     )
                     .FontSize(Sizes.Large * 1.2)
                     .HCenter(),
             }
                 .HeightRequest(36)
                 .WidthRequest(68)
-                .Background(new LinearGradientBrush
-                {
-                    GradientStops =
+                .Background(
+                    new Microsoft.Maui.Controls.LinearGradientBrush
                     {
-                        new GradientStop(
-                            selected ? Styler.Scheme.SecondaryContainer : Colors.Transparent,
-                            0f
-                        ),
-                        new GradientStop(
-                            selected ? Styler.Scheme.Secondary : Colors.Transparent,
-                            1f
-                        ),
-                    },
-                    EndPoint = new Point(1, 1),
-                })
+                        GradientStops =
+                        {
+                            new Microsoft.Maui.Controls.GradientStop(
+                                selected ? Styler.Scheme.SecondaryContainer : Colors.Transparent,
+                                0f
+                            ),
+                            new Microsoft.Maui.Controls.GradientStop(
+                                selected ? Styler.Scheme.Secondary : Colors.Transparent,
+                                1f
+                            ),
+                        },
+                        EndPoint = new Point(1, 1),
+                    }
+                )
                 .ToCard(32)
                 .Padding(0, 4),
             new Label()
@@ -148,8 +164,9 @@ internal class NavigationBar : Component<NavigationBarState>
     {
         if (_items.Any() && State.SelectedItem == null)
         {
-            SetState(s => s.SelectedItem = _items.First());
-            _items.First().NotifyActivated();
+            var first = _items.First();
+            SetState(s => s.SelectedItem = first);
+            first.NotifyActivated();
         }
 
         base.OnMounted();
@@ -159,7 +176,7 @@ internal class NavigationBar : Component<NavigationBarState>
 internal class NavigationBarItem
 {
     private readonly Func<Component> _contentFactory;
-    private Component _content;
+    private Component? _content;
 
     public NavigationBarItem(string title, MaterialIcons icon, Func<Component> contentFactory)
     {

--- a/src/NobUS.Frontend.MAUI/Presentation/Components/SportFacilityList.cs
+++ b/src/NobUS.Frontend.MAUI/Presentation/Components/SportFacilityList.cs
@@ -1,5 +1,13 @@
-﻿using Microsoft.Maui.Graphics;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.Graphics;
 using NobUS.Extra.Campus.Facility.Sports;
+using NobUS.Frontend.MAUI.Presentation;
 using Type = NobUS.Extra.Campus.Facility.Sports.Type;
 
 namespace NobUS.Frontend.MAUI.Presentation.Components;
@@ -7,117 +15,395 @@ namespace NobUS.Frontend.MAUI.Presentation.Components;
 internal class SportFacilityListState
 {
     public Facility[] Facilities { get; set; } = Array.Empty<Facility>();
+    public Dictionary<string, double> PreviousOccupancies { get; set; } = new();
+    public bool IsLoading { get; set; }
+    public bool IsRefreshing { get; set; }
+    public bool IsBackgroundRefreshing { get; set; }
+    public double AnimationProgress { get; set; } = 1;
+    public DateTimeOffset? LastUpdated { get; set; }
+    public string ErrorMessage { get; set; }
 }
 
-internal class SportFacilityList : Component<SportFacilityListState>
+internal class SportFacilityList : Component<SportFacilityListState>, INavigationAware
 {
-    private readonly double _ringSize = 50;
+    private readonly double _ringSize = 54;
+    private bool _isFetching;
 
-    private VisualNode RenderFacility(Facility f) =>
-        new Border
-        {
-            new Grid("auto,*,auto", "*")
+    private enum RefreshTrigger
+    {
+        Initial,
+        Manual,
+        Background,
+    }
+
+    private VisualNode RenderFacility(Facility facility)
+    {
+        double previousOccupancy = State.PreviousOccupancies.TryGetValue(facility.Name, out double previous)
+            ? previous
+            : facility.Occupancy;
+
+        double displayProgress = previousOccupancy + (facility.Occupancy - previousOccupancy) * State.AnimationProgress;
+        displayProgress = Math.Clamp(displayProgress, 0, 1);
+
+        bool highlightChange = Math.Abs(facility.Occupancy - previousOccupancy) > 0.015 && State.AnimationProgress < 1;
+
+        return new Border
             {
-                new GraphicsView()
-                    .HeightRequest(_ringSize)
-                    .WidthRequest(_ringSize)
-                    .Drawable(
-                        new ProgressArc
-                        {
-                            Progress = f.Occupancy,
-                            Name = f.Name,
-                            Type = f.Type,
-                        }
-                    )
-                    .Margin(0, 0, 0, _ringSize / 10)
-                    .GridRow(0),
-                new Label(f.Name)
-                    .Base()
-                    .VerticalOptions(LayoutOptions.Center)
-                    .TextColor(Styler.Scheme.OnSurface)
-                    .SemiBold()
-                    .GridRow(1),
-                new Label($"{f.Load} / {f.Capacity}")
-                    .Regular()
-                    .TextColor(Styler.Scheme.OnSurface)
-                    .SemiBold()
-                    .GridRow(2),
-            }.WidthRequest(100),
-        }
-            .ToCard(20)
-            .Padding(20)
-            .BackgroundColor(Styler.Scheme.SurfaceContainerHigh);
+                new Grid("auto,auto", "auto,*")
+                {
+                    new GraphicsView()
+                        .HeightRequest(_ringSize)
+                        .WidthRequest(_ringSize)
+                        .Drawable(
+                            new ProgressArc
+                            {
+                                Progress = displayProgress,
+                                Type = facility.Type,
+                            }
+                        )
+                        .GridColumn(0)
+                        .GridRowSpan(2)
+                        .Margin(0, 0, 14, 0),
+                    new VerticalStackLayout
+                    {
+                        new Label(facility.Name)
+                            .Medium()
+                            .SemiBold()
+                            .TextColor(Styler.Scheme.OnSurface)
+                            .LineBreakMode(LineBreakMode.TailTruncation),
+                        new Label($"{facility.Load} / {facility.Capacity} in use")
+                            .Small()
+                            .Regular()
+                            .TextColor(Styler.Scheme.OnSurfaceVariant),
+                    }
+                        .GridColumn(1)
+                        .Spacing(2)
+                        .Margin(0, 0, 0, 4),
+                    new Label($"{displayProgress:P0}")
+                        .FontFamily("SemiBold")
+                        .Base()
+                        .TextColor(Styler.Scheme.OnSurface)
+                        .GridColumn(1)
+                        .GridRow(1),
+                }
+                    .ColumnSpacing(14)
+                    .RowSpacing(6),
+            }
+                .ToCard(24)
+                .Padding(18)
+                .Background(
+                    highlightChange ? Styler.Scheme.SecondaryContainer : Styler.Scheme.SurfaceContainerHigh
+                )
+                .Shadow(
+                    new Shadow
+                    {
+                        Brush = new SolidColorBrush(Color.FromArgb("#1A000000")),
+                        Radius = 12,
+                        Opacity = 0.3f,
+                        Offset = new Point(0, 4),
+                    }
+                )
+                .Margin(0, 0, 12, 0);
+    }
 
-    private VisualNode RenderType(Type t) =>
+    private VisualNode RenderType(Type type) =>
         new VerticalStackLayout
         {
-            new Label(t.ToString())
-                .Large()
+            new Label(type.ToString())
+                .Medium()
                 .SemiBold()
-                .GridRow(0)
                 .TextColor(Styler.Scheme.OnSurface)
-                .Margin(0, 0, 0, 5),
+                .Margin(4, 0, 0, 8),
             new CollectionView()
-                .ItemsSource(State.Facilities.Where(f => f.Type == t), RenderFacility)
-                .ItemsLayout(new HorizontalLinearItemsLayout().ItemSpacing(5)),
+                .ItemsSource(State.Facilities.Where(f => f.Type == type), RenderFacility)
+                .ItemsLayout(new HorizontalLinearItemsLayout().ItemSpacing(14))
+                .HorizontalScrollBarVisibility(ScrollBarVisibility.Never),
         };
 
-    public override VisualNode Render() =>
-        new Border
-        {
-            new CollectionView()
-                .ItemsSource(
-                    Enum.GetValues(typeof(Type))
-                        .Cast<Type>()
-                        .Where(t => State.Facilities.Where(f => f.Type == t).Any()),
-                    RenderType
-                )
-                .ItemsLayout(new VerticalLinearItemsLayout().ItemSpacing(5)),
-        }
-            .ToCard(20)
-            .Padding(20)
-            .Background(Styler.Scheme.SurfaceContainer)
-            .VerticalOptions(LayoutOptions.Start)
-            .HorizontalOptions(LayoutOptions.Start);
-
-    protected async Task Load()
+    public override VisualNode Render()
     {
-        var facilities = await Parser.GetAllAsync();
-        SetState(s => s.Facilities = facilities);
+        var sections = Enum.GetValues(typeof(Type))
+            .Cast<Type>()
+            .Where(t => State.Facilities.Any(f => f.Type == t))
+            .ToList();
+
+        return new Grid
+        {
+            new Border
+            {
+                new Grid("auto,auto,*", "*")
+                {
+                    new Grid
+                    {
+                        new Label("Campus activity")
+                            .Large()
+                            .Bold()
+                            .TextColor(Styler.Scheme.OnSurface),
+                        new HorizontalStackLayout
+                        {
+                            State.IsBackgroundRefreshing
+                                ? new Border
+                                    {
+                                        new Label("Updating…")
+                                            .Small()
+                                            .SemiBold()
+                                            .TextColor(Styler.Scheme.Primary),
+                                    }
+                                        .StrokeShape(new RoundRectangle().CornerRadius(12))
+                                        .Background(Styler.Scheme.SurfaceContainerHigh)
+                                        .Padding(8, 4)
+                                        .Margin(0, 0, 8, 0)
+                                : null,
+                            new Border
+                            {
+                                new Label(char.ConvertFromUtf32((int)MaterialIcons.Refresh))
+                                    .FontFamily("MIcon-Regular")
+                                    .FontSize(18)
+                                    .TextColor(Styler.Scheme.OnSecondaryContainer)
+                                    .HCenter()
+                                    .VCenter(),
+                            }
+                                .HeightRequest(40)
+                                .WidthRequest(40)
+                                .Background(Styler.Scheme.SecondaryContainer)
+                                .ToCard(16)
+                                .OnTapped(async () => await LoadAsync(RefreshTrigger.Manual))
+                                .InputTransparent(State.IsRefreshing)
+                                .Opacity(State.IsRefreshing ? 0.6f : 1f),
+                        }
+                            .Spacing(8)
+                            .HEnd(),
+                    }
+                        .ColumnDefinitions("*,auto")
+                        .ColumnSpacing(12),
+                    new Grid
+                    {
+                        new Label(
+                            State.LastUpdated is null
+                                ? "Waiting for the first update"
+                                : $"Last updated • {State.LastUpdated.Value.ToLocalTime():HH:mm:ss}"
+                        )
+                            .Small()
+                            .TextColor(Styler.Scheme.OnSurfaceVariant)
+                            .FontFamily("Regular"),
+                        State.IsRefreshing
+                            ? new ActivityIndicator()
+                                .IsRunning(true)
+                                .HeightRequest(18)
+                                .WidthRequest(18)
+                                .Color(Styler.Scheme.Primary)
+                                .HEnd()
+                                .VCenter()
+                            : null,
+                    }
+                        .ColumnDefinitions("*,auto")
+                        .ColumnSpacing(8)
+                        .GridRow(1),
+                    sections.Any()
+                        ? new CollectionView()
+                            .ItemsSource(sections, RenderType)
+                            .ItemsLayout(new VerticalLinearItemsLayout().ItemSpacing(18))
+                            .GridRow(2)
+                        : State.IsLoading
+                            ? null
+                            : new Label("No live facility information right now.")
+                                .TextColor(Styler.Scheme.OnSurfaceVariant)
+                                .GridRow(2)
+                                .FontFamily("Regular")
+                                .Margin(0, 16, 0, 0),
+                }
+                    .RowSpacing(18),
+            }
+                .Padding(24)
+                .StrokeShape(new RoundRectangle().CornerRadius(32))
+                .StrokeThickness(0)
+                .Stroke(Colors.Transparent)
+                .Background(
+                    new LinearGradientBrush
+                    {
+                        GradientStops =
+                        {
+                            new GradientStop(Styler.Scheme.SurfaceContainerHigh, 0f),
+                            new GradientStop(Styler.Scheme.SurfaceContainer, 1f),
+                        },
+                        EndPoint = new Point(1, 1),
+                    }
+                )
+                .Shadow(
+                    new Shadow
+                    {
+                        Brush = new SolidColorBrush(Color.FromArgb("#20000000")),
+                        Radius = 18,
+                        Opacity = 0.35f,
+                        Offset = new Point(0, 8),
+                    }
+                ),
+            State.IsLoading
+                ? new Grid
+                    {
+                        new ActivityIndicator()
+                            .IsRunning(true)
+                            .Color(Styler.Scheme.Primary)
+                            .HeightRequest(40)
+                            .WidthRequest(40)
+                            .HCenter()
+                            .VCenter(),
+                    }
+                        .BackgroundColor(Styler.Scheme.Surface.WithAlpha(0.65f))
+                        .Padding(32)
+                : null,
+            !string.IsNullOrWhiteSpace(State.ErrorMessage)
+                ? new Border
+                    {
+                        new Label(State.ErrorMessage)
+                            .TextColor(Styler.Scheme.Error)
+                            .FontFamily("SemiBold")
+                            .LineBreakMode(LineBreakMode.WordWrap)
+                            .HCenter(),
+                    }
+                        .Background(Styler.Scheme.ErrorContainer)
+                        .Padding(12)
+                        .ToCard(18)
+                        .Margin(0, 12, 0, 0)
+                        .VerticalOptions(LayoutOptions.End)
+                : null,
+        };
+    }
+
+    private async Task LoadAsync(RefreshTrigger trigger)
+    {
+        if (_isFetching)
+        {
+            return;
+        }
+
+        _isFetching = true;
+
+        bool hasExistingData = State.Facilities.Any();
+
+        SetState(s =>
+        {
+            s.ErrorMessage = null;
+            s.IsLoading = trigger == RefreshTrigger.Initial && !hasExistingData;
+            s.IsRefreshing = trigger == RefreshTrigger.Manual && hasExistingData;
+            s.IsBackgroundRefreshing = trigger == RefreshTrigger.Background && hasExistingData;
+            if (!hasExistingData)
+            {
+                s.AnimationProgress = 0;
+            }
+        });
+
+        try
+        {
+            var facilities = await Parser.GetAllAsync();
+            var previous = State.Facilities.ToDictionary(f => f.Name, f => f.Occupancy);
+
+            SetState(s =>
+            {
+                s.PreviousOccupancies = previous;
+                s.Facilities = facilities;
+                s.LastUpdated = DateTimeOffset.Now;
+                s.IsLoading = false;
+                s.IsRefreshing = false;
+                s.IsBackgroundRefreshing = false;
+                s.AnimationProgress = previous.Count == 0 ? 1 : 0;
+            });
+
+            if (previous.Count > 0)
+            {
+                StartProgressAnimation();
+            }
+        }
+        catch
+        {
+            SetState(s =>
+            {
+                s.IsLoading = false;
+                s.IsRefreshing = false;
+                s.IsBackgroundRefreshing = false;
+                s.ErrorMessage = "Couldn't refresh facility data. Tap refresh to retry.";
+            });
+        }
+        finally
+        {
+            _isFetching = false;
+        }
+    }
+
+    private void StartProgressAnimation()
+    {
+        const double duration = 0.45;
+        DateTimeOffset start = DateTimeOffset.Now;
+
+        var dispatcher = Dispatcher.GetForCurrentThread() ?? Application.Current?.Dispatcher;
+        if (dispatcher is null)
+        {
+            SetState(s =>
+            {
+                s.AnimationProgress = 1;
+                s.PreviousOccupancies = new();
+            });
+            return;
+        }
+
+        dispatcher.StartTimer(TimeSpan.FromMilliseconds(16), () =>
+        {
+            double elapsed = (DateTimeOffset.Now - start).TotalSeconds;
+            double progress = Math.Clamp(elapsed / duration, 0, 1);
+
+            SetState(s =>
+            {
+                s.AnimationProgress = progress;
+                if (progress >= 1)
+                {
+                    s.PreviousOccupancies = new();
+                }
+            });
+
+            return progress < 1;
+        });
     }
 
     protected override async void OnMounted()
     {
-        await Load();
+        await LoadAsync(RefreshTrigger.Initial);
         base.OnMounted();
+    }
+
+    public void OnNavigatedTo()
+    {
+        _ = LoadAsync(RefreshTrigger.Background);
+    }
+
+    public void OnNavigatedFrom()
+    {
     }
 
     private class ProgressArc : IDrawable
     {
         public double Progress { get; set; }
-        public string Name { get; set; }
         public Type Type { get; set; }
 
         public void Draw(ICanvas canvas, RectF dirtyRect)
         {
-            var endAngle = (float)Math.Min(Progress * 360 + 10, 359.999);
+            float sweep = (float)Math.Min(Progress * 360 + 6, 359.99);
             canvas.StrokeColor = Progress switch
             {
-                < 0.25 => Color.FromArgb("#8ecd1e"),
-                < 0.5 => Color.FromArgb("#fffb1d"),
-                < 0.75 => Color.FromArgb("#ffca00"),
-                _ => Color.FromArgb("#ff5252"),
+                < 0.25 => Color.FromArgb("#7BCF4A"),
+                < 0.5 => Color.FromArgb("#FFDD4A"),
+                < 0.75 => Color.FromArgb("#FFC043"),
+                _ => Color.FromArgb("#FF6B6B"),
             };
-            float thickness = dirtyRect.Width / 10;
-            canvas.StrokeSize = thickness;
+            canvas.StrokeSize = dirtyRect.Width / 10;
+            canvas.StrokeLineCap = LineCap.Round;
 
             canvas.DrawArc(
-                thickness / 2,
-                thickness / 2,
-                dirtyRect.Width - thickness,
-                dirtyRect.Width - thickness,
+                canvas.StrokeSize / 2,
+                canvas.StrokeSize / 2,
+                dirtyRect.Width - canvas.StrokeSize,
+                dirtyRect.Height - canvas.StrokeSize,
                 0,
-                endAngle,
+                sweep,
                 false,
                 false
             );

--- a/src/NobUS.Frontend.MAUI/Presentation/Components/StationCard.cs
+++ b/src/NobUS.Frontend.MAUI/Presentation/Components/StationCard.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using CommunityToolkit.Maui.Markup;
-using Microsoft.Maui.Controls;
-using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Graphics;
 using NobUS.DataContract.Model;
 using NobUS.Frontend.MAUI.Presentation;
@@ -15,7 +13,7 @@ namespace NobUS.Frontend.MAUI.Presentation.Components;
 internal class StationCardState
 {
     public bool Expanded { get; set; }
-    public List<ArrivalEventGroup> ArrivalEvents { get; set; }
+    public List<ArrivalEventGroup>? ArrivalEvents { get; set; }
 }
 
 internal partial class StationCard : DisposableComponent<StationCardState>
@@ -56,9 +54,7 @@ internal partial class StationCard : DisposableComponent<StationCardState>
             ? this.UseScheme().Secondary
             : Styler.Scheme.SurfaceContainerHigh;
 
-        string distanceLabel = _distance < 1
-            ? $"{_distance * 1000:0} m"
-            : $"{_distance:0.0} km";
+        string distanceLabel = _distance < 1 ? $"{_distance * 1000:0} m" : $"{_distance:0.0} km";
 
         return new Border
         {
@@ -100,9 +96,6 @@ internal partial class StationCard : DisposableComponent<StationCardState>
                     }
                         .Padding(10, 4)
                         .BackgroundColor(textColor.WithAlpha(0.12f))
-                        .StrokeShape(new RoundRectangle().CornerRadius(12))
-                        .StrokeThickness(0)
-                        .Stroke(Colors.Transparent)
                         .GridColumn(1)
                         .HorizontalOptions(LayoutOptions.End),
                 }
@@ -112,22 +105,24 @@ internal partial class StationCard : DisposableComponent<StationCardState>
                     .FontFamily("ExtraBold")
                     .FontSize(18)
                     .TextColor(textColor)
-                    .LineBreakMode(LineBreakMode.TailTruncation)
+                    .LineBreakMode(Microsoft.Maui.LineBreakMode.TailTruncation)
                     .Margin(0, 8, 0, 0)
                     .OnTapped(Load),
                 !State.Expanded
                     ? null
                     : new Border
                     {
-                        new VerticalStackLayout { State.ArrivalEvents.Select(RenderGroup) }
+                        new VerticalStackLayout
+                        {
+                            (State.ArrivalEvents ?? new List<ArrivalEventGroup>()).Select(
+                                RenderGroup
+                            ),
+                        }
                             .Spacing(10)
                             .Margin(4, 8)
                             .HFill(),
                     }
                         .BackgroundColor(this.UseScheme().SecondaryContainer)
-                        .StrokeShape(new RoundRectangle().CornerRadius(18))
-                        .StrokeThickness(0)
-                        .Stroke(Colors.Transparent)
                         .Padding(12, 10),
             }
                 .Spacing(6)
@@ -135,14 +130,7 @@ internal partial class StationCard : DisposableComponent<StationCardState>
                 .Padding(18, 16),
         }
             .ToCard(28)
-            .Margin(4, 8)
-            .Shadow(new Shadow
-            {
-                Brush = new SolidColorBrush(Color.FromArgb("#12000000")),
-                Radius = 14,
-                Opacity = 0.25f,
-                Offset = new Point(0, 4),
-            });
+            .Margin(4, 8);
     }
 
     private static VisualNode RenderArrivalEvents(ArrivalEvent ae)
@@ -190,11 +178,7 @@ internal partial class StationCard : DisposableComponent<StationCardState>
                     .TextColor(Styler.Scheme.OnSecondary)
                     .FontSize(13)
                     .Margin(6, 2),
-            }
-                .Background(Styler.Scheme.SecondaryContainer)
-                .StrokeShape(new RoundRectangle().CornerRadius(12))
-                .StrokeThickness(0)
-                .Stroke(Colors.Transparent),
+            }.Background(Styler.Scheme.SecondaryContainer),
             new CollectionView()
                 .ItemsSource(grouping.Events, RenderArrivalEvents)
                 .ItemSizingStrategy(ItemSizingStrategy.MeasureAllItems)
@@ -202,8 +186,7 @@ internal partial class StationCard : DisposableComponent<StationCardState>
                 .VerticalScrollBarVisibility(ScrollBarVisibility.Never)
                 .ItemsLayout(new HorizontalLinearItemsLayout().ItemSpacing(6))
                 .Margin(0, 6, 0, 0),
-        }
-            .Spacing(6);
+        }.Spacing(6);
 
     private void Load()
     {

--- a/src/NobUS.Frontend.MAUI/Presentation/Components/StationCard.cs
+++ b/src/NobUS.Frontend.MAUI/Presentation/Components/StationCard.cs
@@ -1,5 +1,10 @@
-﻿using CommunityToolkit.Maui.Markup;
+﻿using System;
+using CommunityToolkit.Maui.Markup;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Graphics;
 using NobUS.DataContract.Model;
+using NobUS.Frontend.MAUI.Presentation;
 using NobUS.Frontend.MAUI.Service;
 using NobUS.Infrastructure;
 using ReactiveUI;
@@ -49,44 +54,95 @@ internal partial class StationCard : DisposableComponent<StationCardState>
         Color textColor = State.Expanded ? this.UseScheme().OnSecondary : Styler.Scheme.OnSurface;
         Color backgroundColor = State.Expanded
             ? this.UseScheme().Secondary
-            : Styler.Scheme.SurfaceContainer;
+            : Styler.Scheme.SurfaceContainerHigh;
+
+        string distanceLabel = _distance < 1
+            ? $"{_distance * 1000:0} m"
+            : $"{_distance:0.0} km";
+
         return new Border
         {
             new VerticalStackLayout
             {
                 new Grid("auto", "*,auto")
                 {
-                    new Label($"{_station.Code} | {_station.Road}")
-                        .GridColumn(0)
-                        .Regular()
-                        .Small()
-                        .HorizontalOptions(LayoutOptions.Start)
-                        .TextColor(textColor),
-                    new Label($"{_distance * 1000:F2}m")
-                        .Regular()
-                        .Small()
+                    new HorizontalStackLayout
+                    {
+                        new Label(char.ConvertFromUtf32((int)MaterialIcons.Route))
+                            .FontFamily("MIcon-Regular")
+                            .FontSize(16)
+                            .TextColor(textColor)
+                            .Opacity(0.75f),
+                        new Label($"{_station.Code} • {_station.Road}")
+                            .FontFamily("SemiBold")
+                            .FontSize(12)
+                            .TextColor(textColor)
+                            .Opacity(0.9f),
+                    }
+                        .Spacing(6)
+                        .GridColumn(0),
+                    new Border
+                    {
+                        new HorizontalStackLayout
+                        {
+                            new Label(char.ConvertFromUtf32((int)MaterialIcons.Place))
+                                .FontFamily("MIcon-Regular")
+                                .FontSize(14)
+                                .TextColor(textColor)
+                                .Opacity(0.85f),
+                            new Label(distanceLabel)
+                                .FontFamily("SemiBold")
+                                .FontSize(12)
+                                .TextColor(textColor),
+                        }
+                            .Spacing(4)
+                            .Padding(0, 0, 2, 0),
+                    }
+                        .Padding(10, 4)
+                        .BackgroundColor(textColor.WithAlpha(0.12f))
+                        .StrokeShape(new RoundRectangle().CornerRadius(12))
+                        .StrokeThickness(0)
+                        .Stroke(Colors.Transparent)
                         .GridColumn(1)
-                        .HorizontalOptions(LayoutOptions.End)
-                        .TextColor(textColor),
-                },
-                new Label(_station.Name).Medium().ExtraBold().OnTapped(Load).TextColor(textColor),
+                        .HorizontalOptions(LayoutOptions.End),
+                }
+                    .ColumnSpacing(12)
+                    .OnTapped(Load),
+                new Label(_station.Name)
+                    .FontFamily("ExtraBold")
+                    .FontSize(18)
+                    .TextColor(textColor)
+                    .LineBreakMode(LineBreakMode.TailTruncation)
+                    .Margin(0, 8, 0, 0)
+                    .OnTapped(Load),
                 !State.Expanded
                     ? null
                     : new Border
                     {
                         new VerticalStackLayout { State.ArrivalEvents.Select(RenderGroup) }
-                            .HFill()
-                            .VFill()
-                            .Margin(5),
+                            .Spacing(10)
+                            .Margin(4, 8)
+                            .HFill(),
                     }
                         .BackgroundColor(this.UseScheme().SecondaryContainer)
-                        .ToCard(20),
+                        .StrokeShape(new RoundRectangle().CornerRadius(18))
+                        .StrokeThickness(0)
+                        .Stroke(Colors.Transparent)
+                        .Padding(12, 10),
             }
+                .Spacing(6)
                 .BackgroundColor(backgroundColor)
-                .Padding(5),
+                .Padding(18, 16),
         }
-            .ToCard(20)
-            .Margin(1, 5);
+            .ToCard(28)
+            .Margin(4, 8)
+            .Shadow(new Shadow
+            {
+                Brush = new SolidColorBrush(Color.FromArgb("#12000000")),
+                Radius = 14,
+                Opacity = 0.25f,
+                Offset = new Point(0, 4),
+            });
     }
 
     private static VisualNode RenderArrivalEvents(ArrivalEvent ae)
@@ -125,21 +181,29 @@ internal partial class StationCard : DisposableComponent<StationCardState>
     }
 
     private static VisualNode RenderGroup(ArrivalEventGroup grouping) =>
-        new HorizontalStackLayout
+        new VerticalStackLayout
         {
-            new Label(grouping.RouteName)
-                .SemiBold()
-                .Base()
-                .TextColor(Styler.Scheme.OnSecondaryContainer),
+            new Border
+            {
+                new Label(grouping.RouteName)
+                    .SemiBold()
+                    .TextColor(Styler.Scheme.OnSecondary)
+                    .FontSize(13)
+                    .Margin(6, 2),
+            }
+                .Background(Styler.Scheme.SecondaryContainer)
+                .StrokeShape(new RoundRectangle().CornerRadius(12))
+                .StrokeThickness(0)
+                .Stroke(Colors.Transparent),
             new CollectionView()
                 .ItemsSource(grouping.Events, RenderArrivalEvents)
                 .ItemSizingStrategy(ItemSizingStrategy.MeasureAllItems)
                 .SelectionMode(SelectionMode.None)
                 .VerticalScrollBarVisibility(ScrollBarVisibility.Never)
-                .ItemsLayout(new HorizontalLinearItemsLayout().ItemSpacing(5)),
+                .ItemsLayout(new HorizontalLinearItemsLayout().ItemSpacing(6))
+                .Margin(0, 6, 0, 0),
         }
-            .Spacing(5)
-            .HeightRequest(Styles.Sizes.Base * 2);
+            .Spacing(6);
 
     private void Load()
     {

--- a/src/NobUS.Frontend.MAUI/Presentation/Components/StationList.cs
+++ b/src/NobUS.Frontend.MAUI/Presentation/Components/StationList.cs
@@ -4,7 +4,6 @@ using CommunityToolkit.Maui.Core.Extensions;
 using CommunityToolkit.Maui.Markup;
 using DynamicData;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Maui.Controls;
 using Microsoft.Maui.Dispatching;
 using Microsoft.Maui.Graphics;
 using NobUS.DataContract.Model;

--- a/src/NobUS.Frontend.MAUI/Presentation/Components/StationList.cs
+++ b/src/NobUS.Frontend.MAUI/Presentation/Components/StationList.cs
@@ -4,7 +4,9 @@ using CommunityToolkit.Maui.Core.Extensions;
 using CommunityToolkit.Maui.Markup;
 using DynamicData;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.Graphics;
 using NobUS.DataContract.Model;
 using NobUS.Frontend.MAUI.Service;
 using ReactiveUI;
@@ -62,7 +64,19 @@ internal partial class StationList : DisposableComponent
             .VerticalScrollBarVisibility(ScrollBarVisibility.Never)
             .SeparatorVisibility(SeparatorVisibility.None)
             .HasUnevenRows(true)
-            .BackgroundColor(Styler.Scheme.Surface);
+            .BackgroundColor(Colors.Transparent)
+            .Margin(24, 0, 24, 120)
+            .RowHeight(-1)
+            .Header(
+                new Grid
+                {
+                    new Label("Nearby bus stops")
+                        .FontFamily("ExtraBold")
+                        .FontSize(22)
+                        .TextColor(Styler.Scheme.OnSurface)
+                        .Margin(0, 24, 0, 12),
+                }
+            );
 
     protected override void OnMounted()
     {

--- a/src/NobUS.Frontend.MAUI/Presentation/PageContainer.cs
+++ b/src/NobUS.Frontend.MAUI/Presentation/PageContainer.cs
@@ -1,4 +1,9 @@
-﻿using NobUS.Frontend.MAUI.Presentation.Components;
+﻿using System;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Shapes;
+using Microsoft.Maui.Graphics;
+using NobUS.Frontend.MAUI.Presentation.Components;
 using NobUS.Frontend.MAUI.Presentation.Pages;
 
 namespace NobUS.Frontend.MAUI.Presentation;
@@ -8,20 +13,59 @@ internal class PageContainer : Component
     public override VisualNode Render()
     {
 #if !WINDOWS
-        CommunityToolkit.Maui.Core.Platform.StatusBar.SetColor(Styler.Scheme.SurfaceContainer);
+        CommunityToolkit.Maui.Core.Platform.StatusBar.SetColor(Styler.Scheme.Primary);
 #endif
+        string greeting = DateTime.Now.Hour switch
+        {
+            < 6 => "Night owl mode",
+            < 9 => "Good morning",
+            < 12 => "Plan the day",
+            < 15 => "Midday momentum",
+            < 18 => "Keep moving",
+            < 21 => "Good evening",
+            _ => "Late-night ride",
+        };
+
         return new ContentPage
         {
             new Grid("auto,*", "*")
             {
-                new Label("NobUS")
-                    .Large()
-                    .Bold()
-                    .TextColor(Styler.Scheme.OnSurface)
-                    .VCenter()
-                    .GridRow(0)
-                    .Padding(10, 5)
-                    .Background(Styler.Scheme.SurfaceContainer),
+                new Border
+                {
+                    new VerticalStackLayout
+                    {
+                        new Label("NobUS")
+                            .FontFamily("ExtraBold")
+                            .FontSize(32)
+                            .TextColor(Styler.Scheme.OnPrimary),
+                        new Label($"{greeting} ✨")
+                            .FontFamily("SemiBold")
+                            .FontSize(16)
+                            .TextColor(Styler.Scheme.OnPrimary)
+                            .Opacity(0.9f),
+                        new Label("Your realtime campus companion")
+                            .FontFamily("Regular")
+                            .FontSize(14)
+                            .TextColor(Styler.Scheme.OnPrimary)
+                            .Opacity(0.75f)
+                            .Margin(0, 6, 0, 0),
+                    }
+                        .Spacing(4),
+                }
+                    .Padding(32, 52, 32, 56)
+                    .Background(new LinearGradientBrush
+                    {
+                        GradientStops =
+                        {
+                            new GradientStop(Styler.Scheme.Primary, 0f),
+                            new GradientStop(Styler.Scheme.Secondary, 1f),
+                        },
+                        EndPoint = new Point(1, 1),
+                    })
+                    .StrokeShape(new RoundRectangle { CornerRadius = new CornerRadius(0, 0, 36, 36) })
+                    .StrokeThickness(0)
+                    .Stroke(Colors.Transparent)
+                    .GridRow(0),
                 new NavigationBar
                 {
                     new NavigationBarItem(
@@ -34,8 +78,11 @@ internal class PageContainer : Component
                         MaterialIcons.FitnessCenter,
                         static () => new ToolsPage()
                     ),
-                }.GridRow(1),
+                }
+                    .GridRow(1)
+                    .Margin(0, -24, 0, 0),
             },
-        };
+        }
+            .Background(Styler.Scheme.Surface);
     }
 }

--- a/src/NobUS.Frontend.MAUI/Presentation/PageContainer.cs
+++ b/src/NobUS.Frontend.MAUI/Presentation/PageContainer.cs
@@ -1,6 +1,5 @@
-﻿using System;
+using System;
 using Microsoft.Maui;
-using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Shapes;
 using Microsoft.Maui.Graphics;
 using NobUS.Frontend.MAUI.Presentation.Components;
@@ -49,40 +48,45 @@ internal class PageContainer : Component
                             .TextColor(Styler.Scheme.OnPrimary)
                             .Opacity(0.75f)
                             .Margin(0, 6, 0, 0),
-                    }
-                        .Spacing(4),
+                    }.Spacing(4),
                 }
                     .Padding(32, 52, 32, 56)
-                    .Background(new LinearGradientBrush
-                    {
-                        GradientStops =
+                    .Background(
+                        new Microsoft.Maui.Controls.LinearGradientBrush
                         {
-                            new GradientStop(Styler.Scheme.Primary, 0f),
-                            new GradientStop(Styler.Scheme.Secondary, 1f),
-                        },
-                        EndPoint = new Point(1, 1),
-                    })
-                    .StrokeShape(new RoundRectangle { CornerRadius = new CornerRadius(0, 0, 36, 36) })
+                            GradientStops =
+                            {
+                                new Microsoft.Maui.Controls.GradientStop(Styler.Scheme.Primary, 0f),
+                                new Microsoft.Maui.Controls.GradientStop(
+                                    Styler.Scheme.Secondary,
+                                    1f
+                                ),
+                            },
+                            EndPoint = new Point(1, 1),
+                        }
+                    )
                     .StrokeThickness(0)
                     .Stroke(Colors.Transparent)
                     .GridRow(0),
-                new NavigationBar
+                new ContentView
                 {
-                    new NavigationBarItem(
-                        "Stations",
-                        MaterialIcons.PinDrop,
-                        static () => new StationList()
-                    ),
-                    new NavigationBarItem(
-                        "Sports",
-                        MaterialIcons.FitnessCenter,
-                        static () => new ToolsPage()
-                    ),
+                    new NavigationBar
+                    {
+                        new NavigationBarItem(
+                            "Stations",
+                            MaterialIcons.PinDrop,
+                            static () => new StationList()
+                        ),
+                        new NavigationBarItem(
+                            "Sports",
+                            MaterialIcons.FitnessCenter,
+                            static () => new ToolsPage()
+                        ),
+                    },
                 }
-                    .GridRow(1)
-                    .Margin(0, -24, 0, 0),
+                    .Margin(0, -24, 0, 0)
+                    .GridRow(1),
             },
-        }
-            .Background(Styler.Scheme.Surface);
+        }.Background(Styler.Scheme.Surface);
     }
 }

--- a/src/NobUS.Frontend.MAUI/Presentation/Pages/ToolsPage.cs
+++ b/src/NobUS.Frontend.MAUI/Presentation/Pages/ToolsPage.cs
@@ -1,8 +1,28 @@
-﻿using NobUS.Frontend.MAUI.Presentation.Components;
+﻿using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using NobUS.Frontend.MAUI.Presentation.Components;
 
 namespace NobUS.Frontend.MAUI.Presentation.Pages;
 
 internal class ToolsPage : Component
 {
-    public override VisualNode Render() => new ScrollView { new SportFacilityList() };
+    public override VisualNode Render() =>
+        new ScrollView
+        {
+            new VerticalStackLayout
+            {
+                new SportFacilityList(),
+            }
+                .Spacing(24)
+                .Padding(24, 0, 24, 120),
+        }
+            .Background(new LinearGradientBrush
+            {
+                GradientStops =
+                {
+                    new GradientStop(Styler.Scheme.SurfaceVariant.WithAlpha(0.08f), 0f),
+                    new GradientStop(Styler.Scheme.Surface, 1f),
+                },
+                EndPoint = new Point(0.5, 1),
+            });
 }

--- a/src/NobUS.Frontend.MAUI/Presentation/Pages/ToolsPage.cs
+++ b/src/NobUS.Frontend.MAUI/Presentation/Pages/ToolsPage.cs
@@ -1,28 +1,52 @@
-﻿using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using NobUS.Frontend.MAUI.Presentation.Components;
 
 namespace NobUS.Frontend.MAUI.Presentation.Pages;
 
-internal class ToolsPage : Component
+internal class ToolsPage : Component, INavigationAware
 {
+    private readonly SportFacilityList _facilityList = new();
+
     public override VisualNode Render() =>
         new ScrollView
         {
             new VerticalStackLayout
             {
-                new SportFacilityList(),
+                new VerticalStackLayout
+                {
+                    new Label("Stay active").Large().Bold().TextColor(Styler.Scheme.OnSurface),
+                    new Label("Live utilisation for campus gyms and courts.")
+                        .Small()
+                        .TextColor(Styler.Scheme.OnSurfaceVariant),
+                }
+                    .Spacing(4)
+                    .Margin(0, 0, 0, 12),
+                _facilityList,
             }
                 .Spacing(24)
                 .Padding(24, 0, 24, 120),
-        }
-            .Background(new LinearGradientBrush
+        }.Background(
+            new Microsoft.Maui.Controls.LinearGradientBrush
             {
                 GradientStops =
                 {
-                    new GradientStop(Styler.Scheme.SurfaceVariant.WithAlpha(0.08f), 0f),
-                    new GradientStop(Styler.Scheme.Surface, 1f),
+                    new Microsoft.Maui.Controls.GradientStop(
+                        Styler.Scheme.SurfaceVariant.WithAlpha(0.08f),
+                        0f
+                    ),
+                    new Microsoft.Maui.Controls.GradientStop(Styler.Scheme.Surface, 1f),
                 },
                 EndPoint = new Point(0.5, 1),
-            });
+            }
+        );
+
+    public void OnNavigatedTo()
+    {
+        _facilityList.OnNavigatedTo();
+    }
+
+    public void OnNavigatedFrom()
+    {
+        _facilityList.OnNavigatedFrom();
+    }
 }


### PR DESCRIPTION
## Summary
- restyle the MAUI shell with a gradient hero header and a modernized navigation bar that keeps tab state alive
- overhaul the sports facility view with cached data, animated refreshes, status messaging, and richer cards
- refresh station list visuals and cards to match the updated design language across the app

## Testing
- `dotnet build NobUS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fdd4f9b3dc8324bfc5e8da3f4ec5a4