### PR TITLE
Fix station list location updates on UI thread

### DIFF
--- a/src/NobUS.Frontend.MAUI/Presentation/Components/StationList.cs
+++ b/src/NobUS.Frontend.MAUI/Presentation/Components/StationList.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive.Linq;
-using Microsoft.Maui.Dispatching;
+using Microsoft.Maui.ApplicationModel;
 using NobUS.DataContract.Model;
 using NobUS.Frontend.MAUI.Service;
 using ReactiveUI;
@@ -14,7 +14,6 @@ internal partial class StationList : DisposableComponent
 {
     private readonly ObservableCollection<Station> _stations = new(GetAllStations);
     private readonly Dictionary<int, double> _distanceLookup = new();
-    private readonly IDispatcher _dispatcher = Dispatcher.GetForCurrentThread()!;
 
     [Inject]
     private ILocationProvider locationProvider = null!;
@@ -80,7 +79,7 @@ internal partial class StationList : DisposableComponent
             .WhereNotNull()
             .Subscribe(location =>
             {
-                _dispatcher.Dispatch(() =>
+                MainThread.BeginInvokeOnMainThread(() =>
                 {
                     var ordered = _stations
                         .OrderBy(station => station.Coordinate.DistanceTo(location))


### PR DESCRIPTION
## Summary
- dispatch station list location reordering via MainThread to avoid dispatcher crashes

## Testing
- dotnet workload restore
- dotnet build NobUS.sln
- dotnet csharpier format .

------
https://chatgpt.com/codex/tasks/task_e_68fecc4da0588324b47e81d2d03f6c2e